### PR TITLE
fix: handle closing of the consumer and websocket

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,13 +188,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.3.2</version>
-                    </dependency>
-                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/gravitee/connector/kafka/ws/WebsocketConnection.java
+++ b/src/main/java/io/gravitee/connector/kafka/ws/WebsocketConnection.java
@@ -43,8 +43,6 @@ public abstract class WebsocketConnection extends AbstractConnection {
                 )
             )
             .endHandler(event -> proxyRequest.close());
-
-        proxyRequest.closeHandler(result -> consumer.unsubscribe().onComplete(event -> consumer.close()));
     }
 
     @Override


### PR DESCRIPTION
**Issue**

gravitee-io/issues#7974

**Description**

The kafka consumer and the application websocket are not well closed when api is stopped (or redeployed)
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-7974-close-consumer-and-ws-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/connector/gravitee-connector-kafka/1.1.1-7974-close-consumer-and-ws-SNAPSHOT/gravitee-connector-kafka-1.1.1-7974-close-consumer-and-ws-SNAPSHOT.zip)
  <!-- Version placeholder end -->
